### PR TITLE
add eslint support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-callback-return": "warn",
+    "brace-style": ["error", "1tbs"],
+    "complexity": ["warn", 20],
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-array-constructor": "error",
+    "no-console": "warn",
+    "no-lonely-if": "warn",
+    "no-loop-func": "warn",
+    "no-mixed-spaces-and-tabs": ["error"],
+    "no-nested-ternary": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "semi": ["error", "always"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", "never"],
+    "keyword-spacing": ["error"],
+    "curly": ["error", "all"]
+  },
+  "globals": {
+    "angular": false,
+  }
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
   - '0.10'
   - '4.4'
 scripts:
+  - npm test
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 before_install:
   - npm install fh-build -g

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,6 +135,9 @@ module.exports = function(grunt) {
           'plato': ['lib/**/*.js']
         }
       }
+    },
+    eslint: {
+      src: ['*.js', 'lib/**/*.js', 'test/**/*.js']
     }
   });
 

--- a/application.js
+++ b/application.js
@@ -6,8 +6,6 @@ var app   = require('./lib/app.js')
   , ip = app.get('base url')
   ;
 
-var tag = 'SERVER';
-
 var server = http.createServer(app);
 server.listen(port, ip, function() {
   console.log("App started at: " + new Date() + " on port: " + port);

--- a/lib/app.js
+++ b/lib/app.js
@@ -39,7 +39,7 @@ app.use('/sys/info/ping', function(req, res) {
 app.use('/api', bodyParser.json({limit: '10mb'}));
 app.use('/box', bodyParser.json());
 app.use('/api', router);
-app.post('/cloud/:datasetId', function(req, res, next) {
+app.post('/cloud/:datasetId', function(req, res) {
   res.send('ok');
 });
 
@@ -52,7 +52,7 @@ require('fh-wfm-workflow/lib/server')(mediator, app, mbaasApi);
 require('fh-wfm-workorder/lib/server')(mediator, app, mbaasApi);
 
 // app modules
-require('./app/message')(mediator)
+require('./app/message')(mediator);
 require('./app/workorder')(mediator);
 require('./app/result')(mediator);
 require('./app/workflow')(mediator);

--- a/lib/app/file.js
+++ b/lib/app/file.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var ArrayStore = require('fh-wfm-mediator/lib/array-store')
+var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 
 var files = [];
 
 module.exports = function(mediator) {
   var arrayStore = new ArrayStore('file', files);
   arrayStore.listen('cloud:', mediator);
-}
+};

--- a/lib/app/group.js
+++ b/lib/app/group.js
@@ -1,14 +1,12 @@
 'use strict';
 
-var ArrayStore = require('fh-wfm-mediator/lib/array-store')
+var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 
 var groups = [
   {id: "Syl1GdSS", name: 'Drivers', role: 'worker'},
   {id: "SyglkfurH", name: 'Back Office', role: 'manager'},
   {id: "rkX1fdSH", name: 'Management', role: 'admin'}
 ];
-
-var nextId = groups.length;
 
 var membership = [
   {id: "rkX1fdSH", group: "Syl1GdSS", user: "rkX1fdSH"},
@@ -27,4 +25,4 @@ module.exports = function(mediator) {
 
   var membershipStore = new ArrayStore('membership', membership);
   membershipStore.listen('cloud:', mediator);
-}
+};

--- a/lib/app/message.js
+++ b/lib/app/message.js
@@ -9,4 +9,4 @@ var messages = [
 module.exports = function(mediator) {
   var arrayStore = new ArrayStore('messages', messages);
   arrayStore.listen('cloud:', mediator);
-}
+};

--- a/lib/app/result.js
+++ b/lib/app/result.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var ArrayStore = require('fh-wfm-mediator/lib/array-store')
+var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 
 var results = [];
 
 module.exports = function(mediator) {
   var arrayStore = new ArrayStore('result', results);
   arrayStore.listen('cloud:', mediator);
-}
+};

--- a/lib/app/workflow.js
+++ b/lib/app/workflow.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ArrayStore = require('fh-wfm-mediator/lib/array-store')
+var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 
 var workflows = [
   { id: "HJ8QkzOSH", title: 'Static forms', steps: [
@@ -29,14 +29,10 @@ var workflows = [
       form: '<vehicle-inspection-form></vehicle-inspection-form>',
       view: '<vehicle-inspection value="result.submission"></vehicle-inspection>'
     }}
-  ]},
-];
-
-var steps = [
-
+  ]}
 ];
 
 module.exports = function(mediator) {
   var arrayStore = new ArrayStore('workflows', workflows);
   arrayStore.listen('cloud:', mediator);
-}
+};

--- a/lib/app/workorder.js
+++ b/lib/app/workorder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ArrayStore = require('fh-wfm-mediator/lib/array-store')
+var ArrayStore = require('fh-wfm-mediator/lib/array-store');
 
 var workorders = [
   { id: "rkX1fdSH", workflowId: 'SyVXyMuSr', assignee: 'rkX1fdSH', type: 'Job Order', title: 'Footpath in disrepair', status: 'New', startTimestamp: '2015-10-22T14:00:00Z', address: '1795 Davie St, Vancouver, BC V6G 2M9', location: [49.287227, -123.141489], summary: 'Please remove damaged kerb and SUPPLY AND FIX 1X DROP KERB CENTRE BN 125 X 150 cart away from site outside number 3.'},
@@ -31,7 +31,7 @@ module.exports = function(mediator) {
     var newDate = index < workorders.length *2 / 3 ? today : tomorrow;
     newDate.setHours(hours);
     workorder.startTimestamp = newDate.getTime();
-  })
+  });
   var arrayStore = new ArrayStore('workorders', workorders);
   arrayStore.listen('cloud:', mediator);
-}
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var cc = require('config-chain')
+var cc = require('config-chain');
 
-var autoconfig = function (overrides) {
+var autoconfig = function(overrides) {
   var config = cc(overrides).add({
     IP: process.env.OPENSHIFT_NODEJS_IP || '0.0.0.0'
   , PORT: process.env.FH_PORT || process.env.OPENSHIFT_NODEJS_PORT || 8001

--- a/lib/mobile-dev.js
+++ b/lib/mobile-dev.js
@@ -16,7 +16,7 @@ app.use(express.static(__dirname + '/../www'));
 
 app.get('/cordova.js', function(req, res) {
   res.send("");
-})
+});
 
 var server = http.createServer(app);
 server.listen(port, ip);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,110 +4,110 @@
   "dependencies": {
     "body-parser": {
       "version": "1.15.0",
-      "from": "body-parser@1.15.0",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
-          "from": "bytes@2.2.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.4.0",
-          "from": "http-errors@>=1.4.0 <1.5.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
               "version": "1.3.0",
-              "from": "statuses@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "from": "iconv-lite@0.4.13",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.1.0",
-          "from": "qs@6.1.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         },
         "raw-body": {
           "version": "2.1.7",
-          "from": "raw-body@>=2.1.5 <2.2.0",
+          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
-              "from": "bytes@2.4.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
           "version": "1.6.13",
-          "from": "type-is@>=1.6.11 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.11",
-              "from": "mime-types@>=2.1.6 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
@@ -118,269 +118,269 @@
     },
     "config-chain": {
       "version": "1.1.10",
-      "from": "config-chain@1.1.10",
+      "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
       "dependencies": {
         "proto-list": {
           "version": "1.2.4",
-          "from": "proto-list@>=1.2.1 <1.3.0",
+          "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
         },
         "ini": {
           "version": "1.3.4",
-          "from": "ini@>=1.3.4 <2.0.0",
+          "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         }
       }
     },
     "cors": {
       "version": "2.7.1",
-      "from": "cors@2.7.1",
+      "from": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "dependencies": {
         "vary": {
           "version": "1.1.0",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "express": {
       "version": "4.13.4",
-      "from": "express@4.13.4",
+      "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.13",
-          "from": "accepts@>=1.2.12 <1.3.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.11",
-              "from": "mime-types@>=2.1.6 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.3",
-              "from": "negotiator@0.5.3",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "array-flatten@1.1.1",
+          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "content-disposition@0.5.1",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
           "version": "0.1.5",
-          "from": "cookie@0.1.5",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
-          "from": "etag@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
           "version": "0.4.1",
-          "from": "finalhandler@0.4.1",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "fresh@0.3.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "merge-descriptors@1.0.1",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "methods@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "parseurl@>=1.3.1 <1.4.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "path-to-regexp@0.1.7",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
           "version": "1.0.10",
-          "from": "proxy-addr@>=1.0.10 <1.1.0",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.0.5",
-              "from": "ipaddr.js@1.0.5",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
             }
           }
         },
         "qs": {
           "version": "4.0.0",
-          "from": "qs@4.0.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "range-parser": {
           "version": "1.0.3",
-          "from": "range-parser@>=1.0.3 <1.1.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
           "version": "0.13.1",
-          "from": "send@0.13.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
-              "from": "destroy@>=1.0.4 <1.1.0",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <1.3.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.10.3",
-          "from": "serve-static@>=1.10.2 <1.11.0",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "dependencies": {
             "send": {
               "version": "0.13.2",
-              "from": "send@0.13.2",
+              "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
               "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@1.3.4",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
@@ -389,22 +389,22 @@
         },
         "type-is": {
           "version": "1.6.13",
-          "from": "type-is@>=1.6.11 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.11",
-              "from": "mime-types@>=2.1.6 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
@@ -413,20 +413,20 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.1",
-          "from": "vary@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
     },
     "fh-mbaas-api": {
-      "version": "5.13.9",
-      "from": "fh-mbaas-api@5.13.9",
-      "resolved": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.13.9.tgz",
+      "version": "5.13.12",
+      "from": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.13.12.tgz",
+      "resolved": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.13.12.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.9",
@@ -449,9 +449,9 @@
           "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
         },
         "fh-db": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.1.2.tgz",
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.2.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.7",
@@ -469,9 +469,9 @@
                   "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "4.1.4",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                      "version": "4.1.6",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
                     },
                     "lazystream": {
                       "version": "1.0.0",
@@ -491,9 +491,9 @@
                   "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
                 },
                 "glob": {
-                  "version": "7.0.5",
-                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+                  "version": "7.0.6",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -518,19 +518,19 @@
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.5",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                          "version": "1.1.6",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.4.1",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                              "version": "0.4.2",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
@@ -561,14 +561,14 @@
                   }
                 },
                 "lodash": {
-                  "version": "4.13.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+                  "version": "4.15.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.1.4",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
+                  "version": "2.1.5",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -764,9 +764,9 @@
                       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                       "dependencies": {
                         "semver": {
-                          "version": "5.2.0",
-                          "from": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
+                          "version": "5.3.0",
+                          "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                         },
                         "resolve-from": {
                           "version": "2.0.0",
@@ -994,9 +994,9 @@
           }
         },
         "fh-mbaas-express": {
-          "version": "5.6.1",
-          "from": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.1.tgz",
+          "version": "5.6.2",
+          "from": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.2.tgz",
           "dependencies": {
             "body-parser": {
               "version": "1.15.2",
@@ -1678,9 +1678,9 @@
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -1734,14 +1734,21 @@
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "1.0.0-rc4",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "1.5.2",
-                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.16.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.0.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -1809,9 +1816,9 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "version": "2.14.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
@@ -1894,9 +1901,9 @@
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
@@ -1904,9 +1911,9 @@
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                      "version": "0.2.3",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
@@ -1916,9 +1923,9 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.9.2",
-                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+                  "version": "1.10.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -1959,6 +1966,18 @@
                       "version": "0.1.1",
                       "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "dependencies": {
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                        }
+                      }
                     }
                   }
                 }
@@ -1980,14 +1999,14 @@
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.1.11",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "2.1.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             },
@@ -2434,59 +2453,59 @@
     },
     "fh-wfm-appform": {
       "version": "0.0.17",
-      "from": "fh-wfm-appform@0.0.17",
+      "from": "https://registry.npmjs.org/fh-wfm-appform/-/fh-wfm-appform-0.0.17.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-appform/-/fh-wfm-appform-0.0.17.tgz",
       "dependencies": {
         "fh-wfm-signature": {
           "version": "0.0.12",
-          "from": "fh-wfm-signature@0.0.12",
+          "from": "https://registry.npmjs.org/fh-wfm-signature/-/fh-wfm-signature-0.0.12.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-signature/-/fh-wfm-signature-0.0.12.tgz"
         }
       }
     },
     "fh-wfm-file": {
       "version": "0.0.6",
-      "from": "fh-wfm-file@0.0.6",
+      "from": "https://registry.npmjs.org/fh-wfm-file/-/fh-wfm-file-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-file/-/fh-wfm-file-0.0.6.tgz",
       "dependencies": {
         "base64-stream": {
           "version": "0.1.3",
-          "from": "base64-stream@0.1.3",
+          "from": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.1.5",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
@@ -2500,54 +2519,54 @@
         },
         "multer": {
           "version": "1.1.0",
-          "from": "multer@1.1.0",
+          "from": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
           "dependencies": {
             "append-field": {
               "version": "0.1.0",
-              "from": "append-field@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz"
             },
             "busboy": {
               "version": "0.2.13",
-              "from": "busboy@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
               "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
               "dependencies": {
                 "dicer": {
                   "version": "0.2.5",
-                  "from": "dicer@0.2.5",
+                  "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
                   "dependencies": {
                     "streamsearch": {
                       "version": "0.1.2",
-                      "from": "streamsearch@0.1.2",
+                      "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2556,47 +2575,47 @@
             },
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@>=1.5.0 <2.0.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -2605,51 +2624,51 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.6.13",
-              "from": "type-is@>=1.6.4 <2.0.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.11",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                     }
                   }
@@ -2658,208 +2677,208 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@2.0.1",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "uuid-js": {
           "version": "0.7.5",
-          "from": "uuid-js@0.7.5",
+          "from": "https://registry.npmjs.org/uuid-js/-/uuid-js-0.7.5.tgz",
           "resolved": "https://registry.npmjs.org/uuid-js/-/uuid-js-0.7.5.tgz"
         }
       }
     },
     "fh-wfm-mediator": {
       "version": "0.0.14",
-      "from": "fh-wfm-mediator@0.0.14",
+      "from": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.0.14.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.0.14.tgz",
       "dependencies": {
         "mediator-js": {
           "version": "0.9.9",
-          "from": "mediator-js@>=0.9.9 <0.10.0",
+          "from": "https://registry.npmjs.org/mediator-js/-/mediator-js-0.9.9.tgz",
           "resolved": "https://registry.npmjs.org/mediator-js/-/mediator-js-0.9.9.tgz"
         }
       }
     },
     "fh-wfm-message": {
       "version": "0.0.10",
-      "from": "fh-wfm-message@0.0.10",
+      "from": "https://registry.npmjs.org/fh-wfm-message/-/fh-wfm-message-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-message/-/fh-wfm-message-0.0.10.tgz",
       "dependencies": {
         "angular-messages": {
           "version": "1.5.3",
-          "from": "angular-messages@1.5.3",
+          "from": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz",
           "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz"
         },
         "fh-wfm-sync": {
           "version": "0.0.12",
-          "from": "fh-wfm-sync@0.0.12",
+          "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "dependencies": {
             "rx": {
               "version": "4.1.0",
-              "from": "rx@4.1.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             }
           }
         },
         "ng-feedhenry": {
           "version": "0.2.53",
-          "from": "ng-feedhenry@0.2.53",
+          "from": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "resolved": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "fhlog": {
               "version": "0.1.6",
-              "from": "fhlog@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "dependencies": {
                 "safejson": {
                   "version": "1.0.1",
-                  "from": "safejson@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
                 },
                 "colors": {
                   "version": "1.0.3",
-                  "from": "colors@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "moment@>=2.8.4 <2.9.0",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "html5-fs": {
                   "version": "0.0.1",
-                  "from": "html5-fs@0.0.1",
+                  "from": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
                 }
               }
             },
             "route-matcher": {
               "version": "0.1.0",
-              "from": "route-matcher@0.1.0",
+              "from": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz"
             },
             "brfs": {
               "version": "1.2.0",
-              "from": "brfs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "dependencies": {
                 "quote-stream": {
                   "version": "0.0.0",
-                  "from": "quote-stream@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "static-module": {
                   "version": "1.3.1",
-                  "from": "static-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.4.10",
-                      "from": "concat-stream@>=1.4.5 <1.5.0",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
@@ -2868,32 +2887,32 @@
                     },
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -2902,32 +2921,32 @@
                     },
                     "escodegen": {
                       "version": "1.3.3",
-                      "from": "escodegen@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "dependencies": {
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "esutils@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "estraverse@>=1.5.0 <1.6.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esprima": {
                           "version": "1.1.1",
-                          "from": "esprima@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.33 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -2936,103 +2955,103 @@
                     },
                     "falafel": {
                       "version": "1.2.0",
-                      "from": "falafel@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.11",
-                          "from": "object-keys@>=1.0.6 <2.0.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
                         }
                       }
                     },
                     "has": {
                       "version": "1.0.1",
-                      "from": "has@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "dependencies": {
                         "function-bind": {
                           "version": "1.1.0",
-                          "from": "function-bind@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                         }
                       }
                     },
                     "object-inspect": {
                       "version": "0.4.0",
-                      "from": "object-inspect@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.27-1 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "shallow-copy": {
                       "version": "0.0.1",
-                      "from": "shallow-copy@>=0.0.1 <0.1.0",
+                      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                     },
                     "static-eval": {
                       "version": "0.2.4",
-                      "from": "static-eval@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "dependencies": {
                         "escodegen": {
                           "version": "0.0.28",
-                          "from": "escodegen@>=0.0.24 <0.1.0",
+                          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "dependencies": {
                             "esprima": {
                               "version": "1.0.4",
-                              "from": "esprima@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                             },
                             "estraverse": {
                               "version": "1.3.2",
-                              "from": "estraverse@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                             },
                             "source-map": {
                               "version": "0.5.6",
-                              "from": "source-map@>=0.1.2",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                             }
                           }
@@ -3043,44 +3062,44 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -3095,133 +3114,133 @@
     },
     "fh-wfm-result": {
       "version": "0.0.10",
-      "from": "fh-wfm-result@0.0.10",
+      "from": "https://registry.npmjs.org/fh-wfm-result/-/fh-wfm-result-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-result/-/fh-wfm-result-0.0.10.tgz",
       "dependencies": {
         "angular-messages": {
           "version": "1.5.3",
-          "from": "angular-messages@1.5.3",
+          "from": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz",
           "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz"
         },
         "fh-wfm-sync": {
           "version": "0.0.12",
-          "from": "fh-wfm-sync@0.0.12",
+          "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "dependencies": {
             "rx": {
               "version": "4.1.0",
-              "from": "rx@4.1.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             }
           }
         },
         "ng-feedhenry": {
           "version": "0.2.53",
-          "from": "ng-feedhenry@0.2.53",
+          "from": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "resolved": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "fhlog": {
               "version": "0.1.6",
-              "from": "fhlog@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "dependencies": {
                 "safejson": {
                   "version": "1.0.1",
-                  "from": "safejson@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
                 },
                 "colors": {
                   "version": "1.0.3",
-                  "from": "colors@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "moment@>=2.8.4 <2.9.0",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "html5-fs": {
                   "version": "0.0.1",
-                  "from": "html5-fs@0.0.1",
+                  "from": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
                 }
               }
             },
             "route-matcher": {
               "version": "0.1.0",
-              "from": "route-matcher@0.1.0",
+              "from": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz"
             },
             "brfs": {
               "version": "1.2.0",
-              "from": "brfs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "dependencies": {
                 "quote-stream": {
                   "version": "0.0.0",
-                  "from": "quote-stream@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "static-module": {
                   "version": "1.3.1",
-                  "from": "static-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.4.10",
-                      "from": "concat-stream@>=1.4.5 <1.5.0",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
@@ -3230,32 +3249,32 @@
                     },
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -3264,32 +3283,32 @@
                     },
                     "escodegen": {
                       "version": "1.3.3",
-                      "from": "escodegen@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "dependencies": {
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "esutils@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "estraverse@>=1.5.0 <1.6.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esprima": {
                           "version": "1.1.1",
-                          "from": "esprima@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.33 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -3298,103 +3317,103 @@
                     },
                     "falafel": {
                       "version": "1.2.0",
-                      "from": "falafel@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.11",
-                          "from": "object-keys@>=1.0.6 <2.0.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
                         }
                       }
                     },
                     "has": {
                       "version": "1.0.1",
-                      "from": "has@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "dependencies": {
                         "function-bind": {
                           "version": "1.1.0",
-                          "from": "function-bind@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                         }
                       }
                     },
                     "object-inspect": {
                       "version": "0.4.0",
-                      "from": "object-inspect@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.27-1 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "shallow-copy": {
                       "version": "0.0.1",
-                      "from": "shallow-copy@>=0.0.1 <0.1.0",
+                      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                     },
                     "static-eval": {
                       "version": "0.2.4",
-                      "from": "static-eval@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "dependencies": {
                         "escodegen": {
                           "version": "0.0.28",
-                          "from": "escodegen@>=0.0.24 <0.1.0",
+                          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "dependencies": {
                             "esprima": {
                               "version": "1.0.4",
-                              "from": "esprima@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                             },
                             "estraverse": {
                               "version": "1.3.2",
-                              "from": "estraverse@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                             },
                             "source-map": {
                               "version": "0.5.6",
-                              "from": "source-map@>=0.1.2",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                             }
                           }
@@ -3405,44 +3424,44 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -3457,12 +3476,12 @@
     },
     "fh-wfm-user": {
       "version": "0.0.21",
-      "from": "fh-wfm-user@0.0.21",
+      "from": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.0.21.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.0.21.tgz",
       "dependencies": {
         "fh-mbaas-api": {
           "version": "5.13.1",
-          "from": "fh-mbaas-api@5.13.1",
+          "from": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.13.1.tgz",
           "resolved": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.13.1.tgz",
           "dependencies": {
             "async": {
@@ -3594,15 +3613,15 @@
                   "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
                 },
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
-                },
                 "es6-promise": {
                   "version": "3.0.2",
                   "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
@@ -3614,15 +3633,15 @@
                   "from": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.4.tgz"
                 },
-                "graceful-fs": {
-                  "version": "4.1.4",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                },
                 "inflight": {
                   "version": "1.0.5",
                   "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+                },
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
@@ -3694,15 +3713,15 @@
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
-                "tar-stream": {
-                  "version": "1.5.2",
-                  "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
-                },
                 "util-deprecate": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                },
+                "tar-stream": {
+                  "version": "1.5.2",
+                  "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
                 },
                 "wrappy": {
                   "version": "1.0.2",
@@ -5296,116 +5315,116 @@
     },
     "fh-wfm-workflow": {
       "version": "0.0.21",
-      "from": "fh-wfm-workflow@0.0.21",
+      "from": "https://registry.npmjs.org/fh-wfm-workflow/-/fh-wfm-workflow-0.0.21.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-workflow/-/fh-wfm-workflow-0.0.21.tgz",
       "dependencies": {
         "ng-feedhenry": {
           "version": "0.2.53",
-          "from": "ng-feedhenry@0.2.53",
+          "from": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "resolved": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "fhlog": {
               "version": "0.1.6",
-              "from": "fhlog@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "dependencies": {
                 "safejson": {
                   "version": "1.0.1",
-                  "from": "safejson@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
                 },
                 "colors": {
                   "version": "1.0.3",
-                  "from": "colors@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "moment@>=2.8.4 <2.9.0",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "html5-fs": {
                   "version": "0.0.1",
-                  "from": "html5-fs@0.0.1",
+                  "from": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
                 }
               }
             },
             "route-matcher": {
               "version": "0.1.0",
-              "from": "route-matcher@0.1.0",
+              "from": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz"
             },
             "brfs": {
               "version": "1.2.0",
-              "from": "brfs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "dependencies": {
                 "quote-stream": {
                   "version": "0.0.0",
-                  "from": "quote-stream@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "static-module": {
                   "version": "1.3.1",
-                  "from": "static-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.4.10",
-                      "from": "concat-stream@>=1.4.5 <1.5.0",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
@@ -5414,32 +5433,32 @@
                     },
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -5448,32 +5467,32 @@
                     },
                     "escodegen": {
                       "version": "1.3.3",
-                      "from": "escodegen@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "dependencies": {
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "esutils@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "estraverse@>=1.5.0 <1.6.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esprima": {
                           "version": "1.1.1",
-                          "from": "esprima@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.33 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -5482,103 +5501,103 @@
                     },
                     "falafel": {
                       "version": "1.2.0",
-                      "from": "falafel@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.11",
-                          "from": "object-keys@>=1.0.6 <2.0.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
                         }
                       }
                     },
                     "has": {
                       "version": "1.0.1",
-                      "from": "has@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "dependencies": {
                         "function-bind": {
                           "version": "1.1.0",
-                          "from": "function-bind@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                         }
                       }
                     },
                     "object-inspect": {
                       "version": "0.4.0",
-                      "from": "object-inspect@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.27-1 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "shallow-copy": {
                       "version": "0.0.1",
-                      "from": "shallow-copy@>=0.0.1 <0.1.0",
+                      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                     },
                     "static-eval": {
                       "version": "0.2.4",
-                      "from": "static-eval@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "dependencies": {
                         "escodegen": {
                           "version": "0.0.28",
-                          "from": "escodegen@>=0.0.24 <0.1.0",
+                          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "dependencies": {
                             "esprima": {
                               "version": "1.0.4",
-                              "from": "esprima@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                             },
                             "estraverse": {
                               "version": "1.3.2",
-                              "from": "estraverse@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                             },
                             "source-map": {
                               "version": "0.5.6",
-                              "from": "source-map@>=0.1.2",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                             }
                           }
@@ -5589,44 +5608,44 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -5639,12 +5658,12 @@
         },
         "fh-wfm-sync": {
           "version": "0.0.12",
-          "from": "fh-wfm-sync@0.0.12",
+          "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "dependencies": {
             "rx": {
               "version": "4.1.0",
-              "from": "rx@4.1.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             }
           }
@@ -5653,133 +5672,133 @@
     },
     "fh-wfm-workorder": {
       "version": "0.0.23",
-      "from": "fh-wfm-workorder@0.0.23",
+      "from": "https://registry.npmjs.org/fh-wfm-workorder/-/fh-wfm-workorder-0.0.23.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-workorder/-/fh-wfm-workorder-0.0.23.tgz",
       "dependencies": {
         "angular-messages": {
           "version": "1.5.3",
-          "from": "angular-messages@1.5.3",
+          "from": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz",
           "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz"
         },
         "fh-wfm-sync": {
           "version": "0.0.12",
-          "from": "fh-wfm-sync@0.0.12",
+          "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.12.tgz",
           "dependencies": {
             "rx": {
               "version": "4.1.0",
-              "from": "rx@4.1.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             }
           }
         },
         "ng-feedhenry": {
           "version": "0.2.53",
-          "from": "ng-feedhenry@0.2.53",
+          "from": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "resolved": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.2.53.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "fhlog": {
               "version": "0.1.6",
-              "from": "fhlog@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.1.6.tgz",
               "dependencies": {
                 "safejson": {
                   "version": "1.0.1",
-                  "from": "safejson@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
                 },
                 "colors": {
                   "version": "1.0.3",
-                  "from": "colors@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "moment@>=2.8.4 <2.9.0",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "html5-fs": {
                   "version": "0.0.1",
-                  "from": "html5-fs@0.0.1",
+                  "from": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
                 }
               }
             },
             "route-matcher": {
               "version": "0.1.0",
-              "from": "route-matcher@0.1.0",
+              "from": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/route-matcher/-/route-matcher-0.1.0.tgz"
             },
             "brfs": {
               "version": "1.2.0",
-              "from": "brfs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.2.0.tgz",
               "dependencies": {
                 "quote-stream": {
                   "version": "0.0.0",
-                  "from": "quote-stream@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "static-module": {
                   "version": "1.3.1",
-                  "from": "static-module@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.4.10",
-                      "from": "concat-stream@>=1.4.5 <1.5.0",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
@@ -5788,32 +5807,32 @@
                     },
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -5822,32 +5841,32 @@
                     },
                     "escodegen": {
                       "version": "1.3.3",
-                      "from": "escodegen@>=1.3.2 <1.4.0",
+                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
                       "dependencies": {
                         "esutils": {
                           "version": "1.0.0",
-                          "from": "esutils@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                         },
                         "estraverse": {
                           "version": "1.5.1",
-                          "from": "estraverse@>=1.5.0 <1.6.0",
+                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                         },
                         "esprima": {
                           "version": "1.1.1",
-                          "from": "esprima@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "source-map@>=0.1.33 <0.2.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -5856,103 +5875,103 @@
                     },
                     "falafel": {
                       "version": "1.2.0",
-                      "from": "falafel@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.11",
-                          "from": "object-keys@>=1.0.6 <2.0.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
                         }
                       }
                     },
                     "has": {
                       "version": "1.0.1",
-                      "from": "has@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                       "dependencies": {
                         "function-bind": {
                           "version": "1.1.0",
-                          "from": "function-bind@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                         }
                       }
                     },
                     "object-inspect": {
                       "version": "0.4.0",
-                      "from": "object-inspect@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.27-1 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "shallow-copy": {
                       "version": "0.0.1",
-                      "from": "shallow-copy@>=0.0.1 <0.1.0",
+                      "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                     },
                     "static-eval": {
                       "version": "0.2.4",
-                      "from": "static-eval@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
                       "dependencies": {
                         "escodegen": {
                           "version": "0.0.28",
-                          "from": "escodegen@>=0.0.24 <0.1.0",
+                          "from": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
                           "dependencies": {
                             "esprima": {
                               "version": "1.0.4",
-                              "from": "esprima@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                             },
                             "estraverse": {
                               "version": "1.3.2",
-                              "from": "estraverse@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
                               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
                             },
                             "source-map": {
                               "version": "0.5.6",
-                              "from": "source-map@>=0.1.2",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                             }
                           }
@@ -5963,44 +5982,44 @@
                 },
                 "through2": {
                   "version": "0.4.2",
-                  "from": "through2@>=0.4.1 <0.5.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "2.1.2",
-                      "from": "xtend@>=2.1.1 <2.2.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                       "dependencies": {
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -6015,174 +6034,174 @@
     },
     "lodash": {
       "version": "4.7.0",
-      "from": "lodash@4.7.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz"
     },
     "mocha": {
       "version": "2.4.5",
-      "from": "mocha@2.4.5",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "commander@2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.4.0",
-          "from": "diff@1.4.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "glob@3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "growl@1.8.1",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "jade@0.26.3",
+          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "commander@0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "supports-color": {
           "version": "1.2.0",
-          "from": "supports-color@1.2.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
     },
     "q": {
       "version": "1.4.1",
-      "from": "q@1.4.1",
+      "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "request": {
       "version": "2.69.0",
-      "from": "request@2.69.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.4.1",
-          "from": "aws4@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "bl": {
           "version": "1.0.3",
-          "from": "bl@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -6191,44 +6210,44 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc3 <1.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "dependencies": {
             "async": {
               "version": "2.0.1",
-              "from": "async@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "4.15.0",
-                  "from": "lodash@>=4.8.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
                 }
               }
@@ -6237,109 +6256,109 @@
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "har-validator@>=2.0.6 <2.1.0",
+          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.13.1",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -6348,106 +6367,106 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.0 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.3.0",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
-                  "from": "json-schema@0.2.2",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "verror@1.3.6",
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.9.2",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.14.0",
-                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                 },
                 "getpass": {
                   "version": "0.1.6",
-                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.13.3",
-                  "from": "tweetnacl@>=0.13.0 <0.14.0",
+                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 }
               }
@@ -6456,66 +6475,66 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.11",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.23.0",
-              "from": "mime-db@>=1.23.0 <1.24.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.0.2",
-          "from": "qs@>=6.0.2 <6.1.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
-          "from": "tough-cookie@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "shortid": {
       "version": "2.2.6",
-      "from": "shortid@>=2.2.6 <3.0.0",
+      "from": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "main": "application.js",
   "scripts": {
     "start": "node application.js",
-    "preinstall": "chmod +x scripts/preinstall.sh && scripts/preinstall.sh"
+    "preinstall": "chmod +x scripts/preinstall.sh && scripts/preinstall.sh",
+    "test": "grunt eslint"
   },
   "keywords": [
     "wfm"
@@ -42,6 +43,7 @@
     "grunt-concurrent": "2.2.1",
     "grunt-contrib-watch": "1.0.0",
     "grunt-env": "0.4.4",
+    "grunt-eslint": "^18.0.0",
     "grunt-node-inspector": ">=0.2.0",
     "grunt-nodemon": "0.4.1",
     "grunt-open": "0.2.3",


### PR DESCRIPTION
Motivation:
Introduce ESLint to this project.

Modifications:
Added grunt-eslint to the required dev dependencies.
Added grunt to be run by Travis (CI).

Result:
ESLint can be run using grunt eslint

JIRA:
https://issues.jboss.org/browse/RAINCATCH-180