### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ services:
 node_js:
   - '0.10'
   - '4.4'
-scripts:
+script:
   - npm test
+  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 before_install:
   - npm install fh-build -g
+  - npm install nsp -g
   - fh-build template
 install: npm install
 notifications:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -168,9 +168,9 @@
               }
             },
             "negotiator": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
@@ -303,9 +303,9 @@
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
-          "version": "0.13.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "version": "0.14.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
@@ -347,9 +347,9 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "dependencies": {
             "send": {
-              "version": "0.13.2",
-              "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+              "version": "0.14.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
@@ -942,9 +942,9 @@
                       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
                     },
                     "moment": {
-                      "version": "2.13.0",
-                      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+                      "version": "2.15.1",
+                      "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                     }
                   }
                 },
@@ -1397,9 +1397,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.7",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "rc": {
                   "version": "0.1.1",
@@ -1623,9 +1623,9 @@
           }
         },
         "moment": {
-          "version": "2.14.1",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
+          "version": "2.15.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
         },
         "mongodb-uri": {
           "version": "0.9.7",
@@ -2424,9 +2424,9 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
@@ -2803,9 +2803,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
-                  "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+                  "version": "2.15.1",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
@@ -3165,9 +3165,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
-                  "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+                  "version": "2.15.1",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
@@ -4181,9 +4181,9 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -4293,9 +4293,9 @@
                           }
                         },
                         "negotiator": {
-                          "version": "0.4.9",
-                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                          "version": "0.6.1",
+                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                         }
                       }
                     },
@@ -4305,9 +4305,9 @@
                       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
                     },
                     "cookie-signature": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                     },
                     "debug": {
                       "version": "2.1.3",
@@ -4315,9 +4315,9 @@
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "dependencies": {
                         "ms": {
-                          "version": "0.7.0",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
@@ -4413,9 +4413,9 @@
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     },
                     "send": {
-                      "version": "0.10.1",
-                      "from": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
+                      "version": "0.14.1",
+                      "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                       "dependencies": {
                         "destroy": {
                           "version": "1.0.3",
@@ -4423,9 +4423,9 @@
                           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                         },
                         "ms": {
-                          "version": "0.6.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         },
                         "on-finished": {
                           "version": "2.1.1",
@@ -4515,9 +4515,9 @@
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.7",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "rc": {
                       "version": "0.1.1",
@@ -4680,14 +4680,14 @@
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.7",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
@@ -4722,9 +4722,9 @@
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                     },
                     "hawk": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "version": "3.1.3",
+                      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
@@ -4807,9 +4807,9 @@
               "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz"
             },
             "moment": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz"
+              "version": "2.15.1",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
             },
             "mongodb-uri": {
               "version": "0.9.7",
@@ -5244,9 +5244,9 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -5349,9 +5349,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
-                  "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+                  "version": "2.15.1",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
@@ -5723,9 +5723,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "moment": {
-                  "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+                  "version": "2.15.1",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
@@ -6075,9 +6075,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
-              "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
@@ -6521,9 +6521,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.2",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "version": "2.3.1",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-209