### PR TITLE
Move auth to before the mbaas routes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -23,10 +23,13 @@ app.use(cors());
 
 // Note: the order which we add middleware to Express here is important!
 app.use('/sys', mbaasExpress.sys(securableEndpoints));
-app.use('/mbaas', mbaasExpress.mbaas);
-
 // Note: important that this is added just before your own Routes
 app.use(mbaasExpress.fhmiddleware());
+
+//Ensuring that any requests to the endpoints must have valid sessions
+//Otherwise, the requests will be rejected.
+app.use(require('fh-wfm-user/lib/middleware/validateSession')(mediator, mbaasApi, ['/authpolicy']));
+app.use('/mbaas', mbaasExpress.mbaas);
 
 // fhlint-begin: custom-routes
 
@@ -42,6 +45,7 @@ app.use('/api', router);
 app.post('/cloud/:datasetId', function(req, res) {
   res.send('ok');
 });
+
 
 // setup the wfm sync & routes
 require('fh-wfm-file/lib/router')(mediator, app);


### PR DESCRIPTION
# Motivations

This change is to protect the /mbaas routes with the session validation. 

This ensures that the sync requests are all validated on the cloud.