### PR TITLE
add security exception for files endpoint

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -58,8 +58,9 @@ app.use('/admin', adminRouter);
 app.post('/cloud/:datasetId', function(req, res) {
   res.send('ok');
 });
-app.use(require('fh-wfm-user/lib/middleware/validateSession')(mediator, mbaasApi, ['/authpolicy']));
 
+var excludedPaths = ['/authpolicy', '/file'];
+app.use(require('fh-wfm-user/lib/middleware/validateSession')(mediator, mbaasApi, excludedPaths));
 
 
 // setup the wfm sync & routes

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "wfm2",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "dependencies": {
     "async": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfm2",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A WFM2 PoC using the mediator pattern",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
   "main": "application.js",


### PR DESCRIPTION
The mobile app is getting a 401 response from file upload as it is not sending a session token with the file upload request. The file URLs for viewing the photos are also getting 401 responses. An exception to the file endpoint has been added to fix this issue.