### PR TITLE
Fix Error Message Typo for Missing Environment Variables

### DIFF
--- a/lib/env-var-check.js
+++ b/lib/env-var-check.js
@@ -1,13 +1,13 @@
 
 /*
- * Check whether the required evnironment variables are
+ * Check whether the required environment variables are
  * set when cloud app starts
  */
 
   if (!process.env.WFM_AUTH_GUID) {
-    console.error('Missing evnironment variable: WFM_AUTH_GUID');
+    console.error('Missing environment variable: WFM_AUTH_GUID');
   }
 
   if (!process.env.WFM_AUTH_POLICY_ID) {
-    console.error('Missing evnironment variable: WFM_AUTH_POLICY_ID');
+    console.error('Missing environment variable: WFM_AUTH_POLICY_ID');
   }


### PR DESCRIPTION
Typo on `environment`