### PR TITLE
🐛 [WIP] Fixes an issue with fh-mbaas-api > 6 that has sync horizontal scaling changes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -67,10 +67,12 @@ var syncOptions =   config.get("syncOptions");
 syncOptions.dataCollisionHandler = globalCollisionHandler;
 
 //Initialising the fh-wfm-sync data sets for each module
-wfmSync.init(mediator, mbaasApi, 'workorders', syncOptions);
-wfmSync.init(mediator, mbaasApi, 'result', syncOptions);
-wfmSync.init(mediator, mbaasApi, 'workflows', syncOptions);
-wfmSync.init(mediator, mbaasApi, 'messages', syncOptions);
+mbaasApi.once('sync_ready', function initDatasets() {
+  wfmSync.init(mediator, mbaasApi, 'workorders', syncOptions);
+  wfmSync.init(mediator, mbaasApi, 'result', syncOptions);
+  wfmSync.init(mediator, mbaasApi, 'workflows', syncOptions);
+  wfmSync.init(mediator, mbaasApi, 'messages', syncOptions);
+});
 
 // setup the wfm sync & routes
 require('fh-wfm-file/lib/router')(mediator, app);


### PR DESCRIPTION
This change listens for the new `sync_ready` event before initialising
datasets.
This should only be merged with an update to the version of fh-mbaas-api that has the new sync horizontal scaling changes