### PR TITLE
Moved user cloud functionality to cloud module

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -32,7 +32,7 @@ app.use(mbaasExpress.fhmiddleware());
 
 //Ensuring that any requests to the endpoints must have valid sessions
 //Otherwise, the requests will be rejected.
-app.use('/mbaas/sync', bodyParser.json({limit: '10mb'}), require('fh-wfm-user/lib/middleware/validateSession')(mediator, mbaasApi, ['/authpolicy']));
+app.use('/mbaas/sync', bodyParser.json({limit: '10mb'}), require('fh-wfm-user/lib/cloud/middleware/validateSession')(mediator, mbaasApi, ['/authpolicy']));
 
 app.use('/mbaas', mbaasExpress.mbaas);
 
@@ -61,7 +61,7 @@ app.post('/cloud/:datasetId', function(req, res) {
 });
 
 var excludedPaths = ['/authpolicy', '/file'];
-app.use(require('fh-wfm-user/lib/middleware/validateSession')(mediator, mbaasApi,excludedPaths));
+app.use(require('fh-wfm-user/lib/cloud/middleware/validateSession')(mediator, mbaasApi,excludedPaths));
 
 var syncOptions =   config.get("syncOptions");
 syncOptions.dataCollisionHandler = globalCollisionHandler;
@@ -76,7 +76,7 @@ wfmSync.init(mediator, mbaasApi, 'messages', syncOptions);
 require('fh-wfm-file/lib/cloud')(mediator, app)
 require('fh-wfm-message/lib/server')(mediator, app, mbaasApi);
 require('fh-wfm-result/lib/cloud')(mediator);
-require('fh-wfm-user/lib/router/cloud')(mediator, app, authServiceGuid);
+require('fh-wfm-user/lib/cloud')(mediator, app, authServiceGuid);
 require('fh-wfm-workflow/lib/cloud')(mediator);
 require('fh-wfm-workorder/lib/cloud')(mediator);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfm2",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "A WFM2 PoC using the mediator pattern",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
   "main": "application.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fh-wfm-message": "0.1.2",
     "fh-wfm-result": "0.2.2",
     "fh-wfm-simple-store": "0.2.2",
-    "fh-wfm-user": "0.5.5",
+    "fh-wfm-user": "0.6.0",
     "fh-wfm-workflow": "0.2.2",
     "fh-wfm-workorder": "0.2.2",
     "fh-wfm-sync": "0.1.2",


### PR DESCRIPTION
Related to https://github.com/feedhenry-raincatcher/raincatcher-user/pull/63 . 

The cloud functionality is now located in the `cloud` folder for consistency.