### PR TITLE
Update server `syncFrequency` value to match client `sync_frequency`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,15 @@
 
 var cc = require('config-chain');
 
+/**
+ * The sync frequency to be passed to fh-wfm-sync.
+ * Sync frequency is set individually for the client and the server.
+ * * On the client the setting is named `sync_frequency`.
+ * * On the server the setting is named `syncFrequency`.
+ * It is recommended that these settings share the same value.
+ */
+var SYNC_FREQUENCY = 5;
+
 var autoconfig = function(overrides) {
   var config = cc(overrides).add({
     IP: process.env.OPENSHIFT_NODEJS_IP || '0.0.0.0',
@@ -9,7 +18,8 @@ var autoconfig = function(overrides) {
     dataTopicPrefix: ':cloud:data',
     persistentStore: process.env.WFM_USE_MEMORY_STORE !== "true",
     syncOptions: {
-      "sync_frequency" : 5,
+      "syncFrequency": SYNC_FREQUENCY,
+      "sync_frequency" : SYNC_FREQUENCY,
       "storage_strategy": "dom",
       "do_console_log": false
     }


### PR DESCRIPTION
Currently the server-side dataset sync frequencies are set to 10 seconds
whereas the client-side dataset sync frequencies are set to 5 seconds.

Having differing sync frequencies can cause unnecessary load on the
server, causing a full sync to be performed twice for each server-side
sync loop frequency.

This change adds the `syncFrequency` option which will default all
server-side datasets to sync every 5 seconds also.

The multiple sync issue has been documented from the following two
issues:

* FH-3018
* FH-3062