### PR TITLE
Bump fh-mbaas-api version

### DIFF
--- a/lib/data_collision_handlers/globalHandler.js
+++ b/lib/data_collision_handlers/globalHandler.js
@@ -5,7 +5,7 @@
  * https://access.redhat.com/documentation/en-us/red_hat_mobile_application_platform_hosted/3/html/cloud_api/fh-sync#fh-sync-handlecollision
  */
 // TODO: Change this function to your own custom collision handler
-module.exports = function(dataset_id, hash, timestamp, uid, pre, post, meta_data, cb) {
+module.exports = function(dataset_id, hash, timestamp, uid, pre, post, meta_data) {
   console.log('./lib/data_collision_handlers/globalHandler.js');
   console.log('**********************************');
   console.log('***  CUSTOM COLLISION HANDLER  ***');
@@ -18,6 +18,5 @@ module.exports = function(dataset_id, hash, timestamp, uid, pre, post, meta_data
   console.log('post', post);
   console.log('meta_data', meta_data);
   console.log('***********************************');
-  cb();
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-demo-cloud",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A WFM2 PoC using the mediator pattern",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
   "main": "application.js",
@@ -20,7 +20,7 @@
     "cors": "2.7.1",
     "debug": "2.6.3",
     "express": "4.15.2",
-    "fh-mbaas-api": "~7.0.1",
+    "fh-mbaas-api": "7.0.8",
     "fh-wfm-file": "0.4.0",
     "fh-wfm-mediator": "0.3.4",
     "fh-wfm-mongoose-store": "0.4.5",


### PR DESCRIPTION
Picking up the latest version of fh-mbaas-api.

The collision handlers no longer have callbacks as part of the $fh.sync API.