### PR TITLE
Use fixed mbaas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cors": "2.8.3",
     "debug": "2.6.8",
     "express": "4.15.3",
-    "fh-mbaas-api": "~7.0.11",
+    "fh-mbaas-api": "7.0.11",
     "fh-wfm-file": "0.4.0",
     "fh-wfm-mediator": "0.3.4",
     "fh-wfm-mongoose-store": "0.4.5",


### PR DESCRIPTION
Use fixed mbaas version as new patch releases introducing breaking change.